### PR TITLE
Read multiple text bubbles from chatbot

### DIFF
--- a/src/text-to-speech-adapter.js
+++ b/src/text-to-speech-adapter.js
@@ -15,7 +15,6 @@ function textToSpeechAdapter(conf) {
     let ttsMessagesQueue = [];
     let speaking = false;
     let finished = true;
-    let playInterval;
 
     // Import ResponsiveVoice library
     importScript({ src: 'https://code.responsivevoice.org/1.5.14/responsivevoice.js' });

--- a/src/text-to-speech-adapter.js
+++ b/src/text-to-speech-adapter.js
@@ -14,6 +14,8 @@ function textToSpeechAdapter(conf) {
   return function(chatbot) {
     let ttsMessagesQueue = [];
     let speaking = false;
+    let finished = true;
+    let playInterval;
 
     // Import ResponsiveVoice library
     importScript({ src: 'https://code.responsivevoice.org/1.5.14/responsivevoice.js' });
@@ -34,24 +36,34 @@ function textToSpeechAdapter(conf) {
     function addTextToQueue(text) {
       if (typeof text === 'string' && text !== '') {
         ttsMessagesQueue.push(text);
-        playMessagesQueue();
+
+        var t=setInterval(function(){
+          if(finished){
+              clearInterval(t);
+              playMessagesQueue();
+          }
+        },300);
       }
     }
 
     // Handle the messages queue
     function playMessagesQueue() {
-      if (window.responsiveVoice && !speaking) {
+      if (window.responsiveVoice && !speaking){
         speaking = conf.useMessagesQueue;
         let nextMessage = ttsMessagesQueue.shift();
-        playText(nextMessage);
+        if(nextMessage !== undefined){
+            playText(nextMessage);
+        }
       }
     }
 
     // Execute TTS library
     function playText(text) {
       let decodedText = decodeEntities(text);
+
+      finished = false
       window.responsiveVoice.speak(decodedText, conf.voice, {
-        onend: finishedPlayingMessage
+          onend: finishedPlayingMessage
       });
     }
 
@@ -67,8 +79,11 @@ function textToSpeechAdapter(conf) {
     // Callback to continue playing the messages queue
     function finishedPlayingMessage() {
       speaking = false;
+
       if (ttsMessagesQueue.length > 0) {
         playMessagesQueue();
+      }else{
+        finished = true;
       }
     }
   }


### PR DESCRIPTION
Whenever the chatbot shows more than 1 text replies, the integration only read the last reply text. The current fix uses an interval to continuously check if the previous reply is completely finished speaking, than it jumps on the next reply. 
Reading the options on a chatbot reply is still impossible